### PR TITLE
Improvements and better error handling

### DIFF
--- a/chart/f7t4jhub/files/jupyterhub-config.py
+++ b/chart/f7t4jhub/files/jupyterhub-config.py
@@ -136,8 +136,8 @@ c.Spawner.batch_script = """#!/bin/bash
 #
 {{ .Values.config.spawner.prelaunchCmds }}
 
-export JUPYTERHUB_API_URL="http://{{ .Values.config.commonName }}/hub/api"
-export JUPYTERHUB_ACTIVITY_URL="http://{{ .Values.config.commonName }}/hub/api/users/${USER}/activity"
+export JUPYTERHUB_API_URL="http://{{ index .Values.config.commonNames 0 }}/hub/api"
+export JUPYTERHUB_ACTIVITY_URL="http://{{ index .Values.config.commonNames 0 }}/hub/api/users/${USER}/activity"
 
 export JUPYTERHUB_OAUTH_ACCESS_SCOPES=$(echo $JUPYTERHUB_OAUTH_ACCESS_SCOPES | base64 --decode)
 export JUPYTERHUB_OAUTH_SCOPES=$(echo $JUPYTERHUB_OAUTH_SCOPES | base64 --decode)

--- a/chart/f7t4jhub/templates/certificate.yaml
+++ b/chart/f7t4jhub/templates/certificate.yaml
@@ -3,10 +3,12 @@ kind: Certificate
 metadata:
   name: {{ .Release.Name }}-cert
 spec:
-  commonName: {{ .Values.config.commonName }}
+  commonName: {{ index .Values.config.commonNames 0 }}
   dnsNames:
-  - {{ .Values.config.commonName }}
+  {{- range .Values.config.commonNames }}
+  - {{ . }}
+  {{- end }}
   issuerRef:
     kind: ClusterIssuer
-    name: letsencrypt
+    name: letsencrypt-http01
   secretName: {{ .Release.Name }}-cert-secret

--- a/chart/f7t4jhub/templates/ingress.yaml
+++ b/chart/f7t4jhub/templates/ingress.yaml
@@ -12,31 +12,35 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: {{ .Values.config.commonName }}
+  {{- range .Values.config.commonNames }}
+  - host: {{ . }}
     http:
       paths:
       - path: /
         pathType: Prefix
         backend:
           service:
-            name: {{ .Release.Name }}-proxy-svc
+            name: {{ $.Release.Name }}-proxy-svc
             port:
-              number: {{ .Values.network.appPort }}
+              number: {{ $.Values.network.appPort }}
       - path: /hub/api
         pathType: Prefix
         backend:
           service:
-            name: {{ .Release.Name }}-proxy-svc
+            name: {{ $.Release.Name }}-proxy-svc
             port:
-              number: {{ .Values.network.appPort }}
+              number: {{ $.Values.network.appPort }}
       - path: /api
         pathType: Prefix
         backend:
           service:
-            name: {{ .Release.Name }}-proxy-svc
+            name: {{ $.Release.Name }}-proxy-svc
             port:
-              number: {{ .Values.network.apiPort }}
+              number: {{ $.Values.network.apiPort }}
+  {{- end }}
   tls:
   - hosts:
-    - {{ .Values.config.commonName }}
+    {{- range .Values.config.commonNames }}
+    - {{ . }}
+    {{- end }}
     secretName: {{ .Release.Name }}-cert-secret

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -170,6 +170,9 @@ f7t4jhub:
       # Name of the partition of the job scheduler (e.g. normal, debug, long)
       partition: '<slurm-partition>'
 
+      # Name of a reservation in the job scheduler
+      reservation: '<slurm-reservation>'
+
       # Constraint for the job scheduler (e.g. gpu, mc, nvgpu)
       constraint: '<slurm-constraint>'
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -120,8 +120,10 @@ f7t4jhub:
     externalPort: 8081
 
   config:
-    # URL for the JupyterHub instance (replace with your own domain)
-    commonName: 'jupyterhub-<cluster-name>.cscs.ch'
+    # List of URLs for the JupyterHub instance
+    commonNames:
+      - 'jupyterhub-<cluster-name-1>.cscs.ch'
+      - 'jupyterhub-<cluster-name-2>.cscs.ch'
 
     # Admin users for the JupyterHub instance (replace with your own admin users)
     adminUsers: '{"user1", "user2"}'

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -28,6 +28,7 @@ RUN . /opt/jhub-env/bin/activate && \
 RUN rm -r /opt/jhub-env/share/jupyterhub/templates
 COPY dockerfiles/cscs-style-jh4/templates       /opt/jhub-env/share/jupyterhub/templates
 COPY dockerfiles/cscs-style-jh4/static/css/cscs /opt/jhub-env/share/jupyterhub/static/css/cscs
+COPY dockerfiles/cscs-style-jh4/static/js/home.js /opt/jhub-env/share/jupyterhub/static/js/home.js
 
 
 EXPOSE 8000

--- a/dockerfiles/cscs-style-jh4/static/js/home.js
+++ b/dockerfiles/cscs-style-jh4/static/js/home.js
@@ -1,0 +1,141 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+require(["jquery", "moment", "jhapi"], function ($, moment, JHAPI) {
+  "use strict";
+
+  var base_url = window.jhdata.base_url;
+  var user = window.jhdata.user;
+  var api = new JHAPI(base_url);
+
+  // Named servers buttons
+
+  function getRow(element) {
+    while (!element.hasClass("home-server-row")) {
+      element = element.parent();
+    }
+    return element;
+  }
+
+  function disableRow(row) {
+    row.find(".btn").attr("disabled", true).off("click");
+  }
+
+  function enableRow(row, running) {
+    // enable buttons on a server row
+    // once the server is running or not
+    row.find(".btn").attr("disabled", false);
+    row.find(".stop-server").click(stopServer);
+    row.find(".delete-server").click(deleteServer);
+
+    if (running) {
+      row.find(".start-server").addClass("hidden");
+      row.find(".delete-server").addClass("hidden");
+      row.find(".stop-server").removeClass("hidden");
+      row.find(".server-link").removeClass("hidden");
+    } else {
+      row.find(".start-server").removeClass("hidden");
+      row.find(".delete-server").removeClass("hidden");
+      row.find(".stop-server").addClass("hidden");
+      row.find(".server-link").addClass("hidden");
+    }
+  }
+
+  function startServer() {
+    var row = getRow($(this));
+    var serverName = row.find(".new-server-name").val();
+    if (serverName === "") {
+      // ../spawn/user/ causes a 404, ../spawn/user redirects correctly to the default server
+      window.location.href = "./spawn/" + user;
+    } else {
+      window.location.href = "./spawn/" + user + "/" + serverName;
+    }
+  }
+
+  function stopServer() {
+    var row = getRow($(this));
+    var serverName = row.data("server-name");
+
+    // before request
+    disableRow(row);
+
+    // request
+    api.stop_named_server(user, serverName, {
+      success: function () {
+        enableRow(row, false);
+      },
+    });
+  }
+
+  function deleteServer() {
+    var row = getRow($(this));
+    var serverName = row.data("server-name");
+
+    // before request
+    disableRow(row);
+
+    // request
+    api.delete_named_server(user, serverName, {
+      success: function () {
+        row.remove();
+      },
+    });
+  }
+
+  // initial state: hook up click events
+  $("#stop").click(function () {
+
+    // check if credentials are valid
+    var isValid = $(this).data("access-token-is-valid");
+    var isRunning = $(this).data("access-server-is-running");
+    
+        if (!isValid && isRunning) {
+            // Display the message in your custom style
+            $("#note-note span.info-block")
+                .html('<br><i class="fa fa-info-circle"></i> Your session has expired. Please <a href="/hub/logout">log out</a> and log back in to refresh your credentials.')
+                .closest("#note-note") // Show the parent <p> element
+                .show();
+            return; // Prevent further execution
+        }
+
+    // original script
+    $("#start")
+      .attr("disabled", true)
+      .attr("title", "Your server is stopping")
+      .click(function () {
+        return false;
+      });
+    api.stop_server(user, {
+      success: function () {
+        $("#stop").hide();
+        $("#start")
+          .text("Start My Server")
+          .attr("title", "Start your default server")
+          .attr("disabled", false)
+          .attr("href", base_url + "spawn/" + user)
+          .off("click");
+      },
+    });
+  });
+
+  $(".new-server-btn").click(startServer);
+  $(".new-server-name").on("keypress", function (e) {
+    if (e.which === 13) {
+      startServer.call(this);
+    }
+  });
+
+  $(".stop-server").click(stopServer);
+  $(".delete-server").click(deleteServer);
+
+  // render timestamps
+  $(".time-col").map(function (i, el) {
+    // convert ISO datestamps to nice momentjs ones
+    el = $(el);
+    var m = moment(new Date(el.text().trim()));
+    el.text(m.isValid() ? m.fromNow() : "Never");
+  });
+
+  // signal that page has finished loading (mostly for tests)
+  window._jupyterhub_page_loaded = true;
+});

--- a/dockerfiles/cscs-style-jh4/templates/home.html
+++ b/dockerfiles/cscs-style-jh4/templates/home.html
@@ -104,42 +104,60 @@
 
 <script>
 
-
-    setTimeout(function() {
-        // Find the "Stop My Server" button
-        const stopButton = document.getElementById("stop");
-
-        if (stopButton) {
-            // Get the parent element of the button
-            const parent = stopButton.parentNode;
-
-            // Remove the original "Stop My Server" button
-            parent.removeChild(stopButton);
+    // Track the last time the page was active
+    let lastActiveTime = Date.now();
+    
+    // Threshold for refresh (5 hours in milliseconds)
+    const refreshThreshold = 10 * 1000; // 5 hours
+    
+    // Function to handle tab visibility change
+    document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible") {
+            // Calculate time elapsed since the page was last active
+            const now = Date.now();
+            const timeElapsed = now - lastActiveTime;
+    
+            if (timeElapsed > refreshThreshold) {
+                location.reload();
+            }
         }
+    });
 
-        const startButton = document.getElementById("start");
-
-        if (startButton.textContent.trim() === "My Server") {
-            // Get the parent element of the button
-            parent = startButton.parentNode;
-
-            // Create the new refresh button
-            const refreshButton = document.createElement("button");
-            refreshButton.textContent = "Refresh Page";
-            refreshButton.className = "btn btn-lg btn-cscs-darkred"; // Add any desired styles here
-            refreshButton.onclick = function() {
-                location.reload(); // Refresh the page
-            };
-
-            // Insert the new refresh button into the parent element
-            parent.appendChild(refreshButton);
-
-            // Remove the original "Stop My Server" button
-            parent.removeChild(startButton);
-        }
-
-
-    }, 10000); // in milliseconds	
+//    setTimeout(function() {
+//        // Find the "Stop My Server" button
+//        const stopButton = document.getElementById("stop");
+//
+//        if (stopButton) {
+//            // Get the parent element of the button
+//            const parent = stopButton.parentNode;
+//
+//            // Remove the original "Stop My Server" button
+//            parent.removeChild(stopButton);
+//        }
+//
+//        const startButton = document.getElementById("start");
+//
+//        if (startButton.textContent.trim() === "My Server") {
+//            // Get the parent element of the button
+//            parent = startButton.parentNode;
+//
+//            // Create the new refresh button
+//            const refreshButton = document.createElement("button");
+//            refreshButton.textContent = "Refresh Page";
+//            refreshButton.className = "btn btn-lg btn-cscs-darkred"; // Add any desired styles here
+//            refreshButton.onclick = function() {
+//                location.reload(); // Refresh the page
+//            };
+//
+//            // Insert the new refresh button into the parent element
+//            parent.appendChild(refreshButton);
+//
+//            // Remove the original "Stop My Server" button
+//            parent.removeChild(startButton);
+//        }
+//
+//
+//    }, 10000); // in milliseconds	
 
 </script>
 

--- a/dockerfiles/cscs-style-jh4/templates/home.html
+++ b/dockerfiles/cscs-style-jh4/templates/home.html
@@ -12,7 +12,8 @@
         <a id="stop"
 	   role="button"
 	   class="btn btn-lg btn-cscs-darkred outline"
-	   data-access-token-is-valid="{{ default_server.access_token_is_valid | lower }}">
+	   data-access-token-is-valid="{{ default_server.access_token_is_valid | lower }}"
+	   data-access-server-is-running="{{ default_server.user.running | lower }}">
            Stop My Server
         </a>
       {% endif %}

--- a/dockerfiles/cscs-style-jh4/templates/page.html
+++ b/dockerfiles/cscs-style-jh4/templates/page.html
@@ -218,7 +218,7 @@
           </ul>
       </div>
       <div class="c-copyright">
-          2024 © CSCS&nbsp;|&nbsp;<a href="http://www.cscs.ch" target="_blank">www.cscs.ch</a>
+          2025 © CSCS&nbsp;|&nbsp;<a href="http://www.cscs.ch" target="_blank">www.cscs.ch</a>
       </div>
   </footer> 
 

--- a/dockerfiles/cscs-style-jh4/templates/spawn.html
+++ b/dockerfiles/cscs-style-jh4/templates/spawn.html
@@ -23,6 +23,11 @@
                   The credentials for spawning a new job have expired. <br>
                   Please <a href="/hub/logout">log out</a> and log back in.
               </p>
+	          {% elif "HTTP 400" in error_message or "Session not active" in error_message %}
+              <p>
+                  The Keycloak single-sign on session has expired. <br>
+                  Please <a href="/hub/logout">log out</a> and log back in.
+              </p>
 	          {% else %}
               <p>
 	          {{ error_message }}

--- a/dockerfiles/cscs-style-jh4/templates/spawn.html
+++ b/dockerfiles/cscs-style-jh4/templates/spawn.html
@@ -18,10 +18,16 @@
         </p> -->
         <div>
           {% if error_message %}
+	          {% if "HTTP 401" in error_message %}
               <p>
                   The credentials for spawning a new job have expired. <br>
                   Please <a href="/hub/logout">log out</a> and log back in.
               </p>
+	          {% else %}
+              <p>
+	          {{ error_message }}
+              </p>
+	          {% endif %}
           {% endif %}
         </div>
       {% endif %}

--- a/firecrestspawner/spawner.py
+++ b/firecrestspawner/spawner.py
@@ -386,7 +386,8 @@ class FirecRESTSpawnerBase(Spawner):
 
         client = await self.get_firecrest_client()
         groups = await client.groups(self.host)
-        if subvars["account"] == [""] or not subvars["account"]:
+        account_from_form = self.user_options.get("account")
+        if not account_from_form or account_from_form == [""]:
             subvars["account"] = groups["group"]["name"]
 
         script = await self._get_batch_script(**subvars)

--- a/firecrestspawner/spawner.py
+++ b/firecrestspawner/spawner.py
@@ -555,7 +555,7 @@ class FirecRESTSpawnerBase(Spawner):
         # So this function should not return unless successful, and if
         # unsuccessful should either raise and Exception or loop forever.
         if len(self.job_id) == 0:
-            message = "Jupyter batch job submission failure: no jobid in output "
+            message = "Jupyter batch job submission failure: no jobid in output"
             if ret:
                 if ret.responses[-1].status_code == 200:
                     byte_content = ret.responses[-1].content

--- a/firecrestspawner/version.py
+++ b/firecrestspawner/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.1"
+VERSION = "0.1.2"

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -396,6 +396,23 @@ async def test_start_job_fail(db, fc_server):
 
 
 @pytest.mark.asyncio
+async def test_submit_batch_script_no_jobid(db, fc_server):
+    spawner = new_spawner(db=db)
+    spawner.firecrest_url = fc_server.url_for("/")
+    spawner.user.authenticator.token_url = "".join([
+        fc_server.url_for("/") ,
+        "auth/realms/kcrealm/protocol/openid-connect/token"
+    ])
+    spawner.set_trait("req_partition", "no_jobid")
+    ret = await spawner.submit_batch_script()
+    byte_content = ret.responses[-1].content
+    decoded_string = byte_content.decode('utf-8')
+    response_dict = json.loads(decoded_string)
+    message =  list(response_dict["tasks"].values())[0]["data"]
+    assert message == "sbatch: error: cli_filter plugin terminated with error"
+
+
+@pytest.mark.asyncio
 async def test_start_no_jobid(db, fc_server):
     spawner = new_spawner(db=db)
     spawner.firecrest_url = fc_server.url_for("/")

--- a/tests/test_spawner.py
+++ b/tests/test_spawner.py
@@ -408,7 +408,7 @@ async def test_start_no_jobid(db, fc_server):
         await spawner.start()
 
     assert str(excinfo.value) == (
-        "Jupyter batch job submission " "failure: (no jobid in output)"
+        "Jupyter batch job submission failure: no jobid in output"
     )
     assert spawner.job_status == ""
 


### PR DESCRIPTION
- Closes #57
- Closes #54 
- The Slurm account, constraint and reservation parameters can be set by the user in the options form
- A default reservation can be set in the `values.yaml`
- The "Stop server / My Server" pages reloads if visited after a time of inactivity
- The reason for a submission failure is shown to the user instead of the generic "no job id in the output"
- Job id is shown while the job is pending
- The user is notified when starting or closing a server within an expired SSO session
- Allow multiple ingress
- Update copyright year