### PR TITLE
Remove the server-snippet annotation from ingress

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: f7t4jhub
 description: A Helm chart to Deploy JupyterHub with the FirecREST Spawner
 type: application
-version: 0.9.5-dev.3
+version: 0.9.5-dev.4
 appVersion: "4.1.6"
 dependencies:
   - name: f7t4jhub
-    version: 0.9.5-dev.3
+    version: 0.9.5-dev.4
     repository: "file://./f7t4jhub"
   - name: reloader
     version: v1.0.51

--- a/chart/f7t4jhub/Chart.yaml
+++ b/chart/f7t4jhub/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: f7t4jhub
 description: A Helm chart to Deploy JupyterHub with the FirecREST Spawner
 type: application
-version: 0.9.5-dev.3
+version: 0.9.5-dev.4
 appVersion: "4.1.6"

--- a/chart/f7t4jhub/templates/ingress-deny-metrics.yaml
+++ b/chart/f7t4jhub/templates/ingress-deny-metrics.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.metricbeat.deny_metrics_endpoint }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-deny-metrics-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/deny-all: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+  {{- range $issuer, $config := .Values.config.certificates }}
+    {{- range $config.urls }}
+  - host: {{ . }}
+    http:
+      paths:
+      - path: /hub/metrics
+        pathType: Prefix
+        backend:
+          service:
+            name: fake-service
+            port:
+              number: 80  # Dummy backend, never actually used
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/chart/f7t4jhub/templates/ingress.yaml
+++ b/chart/f7t4jhub/templates/ingress.yaml
@@ -2,13 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-proxy-ingress
-  annotations:
-    {{- if .Values.metricbeat.deny_metrics_endpoint }}
-    nginx.ingress.kubernetes.io/server-snippet: |
-      location /hub/metrics {
-        deny all;
-      }
-    {{- end }}
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
Custom NGINX configurations using snippets were disabled due to security concerns. This means that the annotation `nginx.ingress.kubernetes.io/server-snippet` cannot be used.