### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     name: Run Unit Tests
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/eth-cscs/firecrestspawner/security/code-scanning/2](https://github.com/eth-cscs/firecrestspawner/security/code-scanning/2)

To resolve the issue, we must explicitly declare a `permissions` block to restrict the GITHUB_TOKEN permissions for this job (or the entire workflow) to the minimal level required. As none of the steps write to the repository, the minimal necessary permission is `contents: read`. It's best practice to include this either at the workflow root (to cover all jobs) or at the job level if other jobs might require different permissions; in this case, adding it at the job level for `test` is sufficient and most precise. This change involves inserting the following block:

```yaml
permissions:
  contents: read
```

immediately after the job definition line (`test:`), i.e., after line 13, before line 14 in `.github/workflows/unittests.yml`. No imports or other definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
