### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/eth-cscs/firecrestspawner/security/code-scanning/4](https://github.com/eth-cscs/firecrestspawner/security/code-scanning/4)

To fix this problem, we should add a `permissions` block specifying the minimal required permissions for the job. Since this workflow creates commits and pushes to branches (using git) and then creates a pull request (using `gh pr create`), it minimally requires `contents: write` (for committing/pushing to a branch) and `pull-requests: write` (for creating a PR). The optimal solution is to place a `permissions` block either at the workflow root (to apply to all jobs) or at the `build` job level. Since there is only one job, it may be slightly preferable (and clearer for future extension) to set it at the job level.

Change needed:
- Insert the following block under the `build:` job definition and above `runs-on`:
  ```yaml
  permissions:
    contents: write
    pull-requests: write
  ```

No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
