### PR TITLE
Add VS Code integration for JupyterHub

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -6,6 +6,7 @@ FROM base AS builder
 
 RUN apt-get update -qq \
     && apt-get install -yqq --no-install-recommends --no-install-suggests \
+    curl \
     wget \
     unzip \
     git \
@@ -18,6 +19,9 @@ RUN apt-get update -qq \
 COPY requirements.txt .
 RUN python -m pip install --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Install code-server
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/usr/local --version=4.109.2
 
 COPY . firecrestspawner
 

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -2,4 +2,4 @@
 
 This is a dockerfile to build the image used for the deployment of the Hub.
 
-The available images can be found [here](https://github.com/eth-cscs/firecrestspawner/pkgs/container/f7t4fjhub).
+The available images can be found [here](https://github.com/eth-cscs/firecrestspawner/pkgs/container/f7t4jhub).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+jupyter_server_proxy==4.4.0
+jupyter_vscode_proxy==0.7
 jupyterhub==4.1.6
 pyfirecrest==3.3.1
 SQLAlchemy==1.4.52


### PR DESCRIPTION
This should tentatively add VS Code (via [code-server](https://github.com/coder/code-server)) support to the [JupyterLab service](https://docs.cscs.ch/access/jupyterlab/) provided by CSCS.

VS Code is accessed from the JupyterLab interface, which takes care of proxying via [jupyter-server-proxy](https://github.com/jupyterhub/jupyter-server-proxy). The specific entrypoint for VS Code is provided by [jupyter-vscode-proxy](https://github.com/betatim/vscode-binder), though it can be easily extended to support other server flavors like VS Codium's [web host releases](https://github.com/VSCodium/vscodium/releases), custom icons, etc.

I tested the new requirements and the Dockerfile build, but didn't test the actual image. However, I'm using a similar setup with [my own image](https://github.com/ltpn/nedoqs-tutorials/pkgs/container/nedoqs-tutorials) and my own k8s cluster, this is what it looks like:

https://github.com/user-attachments/assets/75e7d9fe-c1a8-4853-8edf-6caa6f5b0ec4

